### PR TITLE
Migrate NFS provisioner to v4.0.2 to fix CrashLoopBackOff

### DIFF
--- a/nfs-deployment.yaml
+++ b/nfs-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: nfs-client-provisioner
       containers:
         - name: nfs-client-provisioner
-          image: quay.io/external_storage/nfs-client-provisioner:latest
+          image: registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2
           volumeMounts:
             - name: nfs-client-root
               mountPath: /persistentvolumes


### PR DESCRIPTION
- Changed from quay.io/external_storage (deprecated) 
- To registry.k8s.io/sig-storage (official maintained)
- Fixes "selfLink was empty" error on K8s 1.20+